### PR TITLE
github_actions静的解析 検証用3

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -41,13 +41,3 @@ jobs:
       # 静的解析
       - name: Lint with detekt
         run: ./gradlew detekt
-      # アーティファクトへアップロード
-      - name: Upload results Artifact
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: results
-          path: |
-            hello-app/app/build/reports/detekt/detekt.xml
-          if-no-files-found: error
-          retention-days: 14

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -22,14 +22,3 @@ jobs:
           cache: gradle
       - run: ./gradlew lint
       - uses: yutailang0119/action-android-lint@v4
-        with:
-          report-path: 'hello-app/app/*'
-      # アーティファクトへアップロード
-      - name: Upload results Artifact
-        uses: actions/upload-artifact@v4
-        if: success() || failure()
-        with:
-          name: results
-          path: |
-            hello-app/app/*
-          retention-days: 14

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,6 +24,15 @@ jobs:
       - uses: yutailang0119/action-android-lint@v4
         with:
           report-path: 'hello-app/app/build/reports/*.xml'
+      - name: Generate lint report
+        run: ./gradlew lint
+      # Lintレポートが生成されるディレクトリを指定
+        working-directory: hello-app/app
+      - name: Upload lint report
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-reports
+          path: hello-app/app/build/reports/lint
       # アーティファクトへアップロード
       - name: Upload results Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -38,6 +38,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # 静的解析
+        with:
+          fetch-depth: 1
+      - name: set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+          cache: gradle
+      # detekt を実行して、コードの静的解析を行います
       - name: Lint with detekt
         run: ./gradlew detekt

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,16 +1,24 @@
+# name: このワークフローの名前
 name: Android CI lint demo
 
-# 実行の条件
+# on: 実行の条件
 on:
+  # pull_request: プルリクエストが作成されたときに実行
   pull_request:
+    # paths: 特定のファイルパスに変更があった場合にのみ実行
     paths:
+      # このワークフローファイル自体が変更された場合
       - .github/workflows/android.yml
+      # src ディレクトリ以下に変更があった場合
       - '*/src/**'
 
 jobs:
+  # ジョブの名前
   android-lint:
+    # runs-on: 実行環境の種類
     runs-on: ubuntu-latest
     steps:
+      # リポジトリのコードをワークスペースにチェックアウトする
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
@@ -20,6 +28,7 @@ jobs:
           distribution: zulu
           java-version: 17
           cache: gradle
+      # Gradle の lint タスクを実行して、コードの静的解析を行います
       - run: ./gradlew lint
       - uses: yutailang0119/action-android-lint@v4
         with:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -37,13 +37,13 @@ jobs:
   detekt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # 静的解析
       - name: Lint with detekt
         run: ./gradlew detekt
       # アーティファクトへアップロード
       - name: Upload results Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: results

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,7 +23,7 @@ jobs:
       - run: ./gradlew lint
       - uses: yutailang0119/action-android-lint@v4
         with:
-          report-path: 'hello-app/app'
+          report-path: 'hello-app/app/*'
       # アーティファクトへアップロード
       - name: Upload results Artifact
         uses: actions/upload-artifact@v4
@@ -31,5 +31,5 @@ jobs:
         with:
           name: results
           path: |
-            hello-app/app
+            hello-app/app/*
           retention-days: 14

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,4 +1,4 @@
-name: Android CI lint
+name: Android CI lint demo
 
 # 実行の条件
 on:
@@ -23,16 +23,7 @@ jobs:
       - run: ./gradlew lint
       - uses: yutailang0119/action-android-lint@v4
         with:
-          report-path: 'hello-app/app/build/reports/*.xml'
-      - name: Generate lint report
-        run: ./gradlew lint
-      # Lintレポートが生成されるディレクトリを指定
-        working-directory: hello-app/app
-      - name: Upload lint report
-        uses: actions/upload-artifact@v4
-        with:
-          name: lint-reports
-          path: hello-app/app/build/reports/lint
+          report-path: 'hello-app/app/*.xml'
       # アーティファクトへアップロード
       - name: Upload results Artifact
         uses: actions/upload-artifact@v4
@@ -40,5 +31,5 @@ jobs:
         with:
           name: results
           path: |
-            hello-app/app/build/reports/*.xml
+            hello-app/app/*.xml
           retention-days: 14

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -22,3 +22,5 @@ jobs:
           cache: gradle
       - run: ./gradlew lint
       - uses: yutailang0119/action-android-lint@v4
+        with:
+          report-path: 'hello-app/app/build/reports/*.xml'

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -33,19 +33,30 @@ jobs:
       - uses: yutailang0119/action-android-lint@v4
         with:
           report-path: 'hello-app/app/build/reports/*.xml'
-  # detekt のジョブ
-  detekt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+      # アーティファクトへアップロード
+      - name: Upload results Artifact
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
         with:
-          fetch-depth: 1
-      - name: set up JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: zulu
-          java-version: 17
-          cache: gradle
-      # detekt を実行して、コードの静的解析を行います
-      - name: Lint with detekt
-        run: ./gradlew detekt
+          name: results
+          path: |
+            **/build/reports/lint-results-*.html
+            **/build/reports/lint-results-*.xml
+          if-no-files-found: error
+          retention-days: 14
+  # # detekt のジョブ
+  # detekt:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 1
+  #     - name: set up JDK
+  #       uses: actions/setup-java@v4
+  #       with:
+  #         distribution: zulu
+  #         java-version: 17
+  #         cache: gradle
+  #     # detekt を実行して、コードの静的解析を行います
+  #     - name: Lint with detekt
+  #       run: ./gradlew detekt

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -48,6 +48,6 @@ jobs:
         with:
           name: results
           path: |
-            **/build/reports/detekt/*
+            hello-app/app/build/reports/detekt/detekt.xml
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,7 +23,7 @@ jobs:
       - run: ./gradlew lint
       - uses: yutailang0119/action-android-lint@v4
         with:
-          report-path: 'hello-app/app/*.xml'
+          report-path: 'hello-app/app'
       # アーティファクトへアップロード
       - name: Upload results Artifact
         uses: actions/upload-artifact@v4
@@ -31,5 +31,5 @@ jobs:
         with:
           name: results
           path: |
-            hello-app/app/*.xml
+            hello-app/app
           retention-days: 14

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,8 +13,8 @@ on:
       - '*/src/**'
 
 jobs:
-  # ジョブの名前
-  android-lint:
+  # lint のジョブ
+  lint:
     # runs-on: 実行環境の種類
     runs-on: ubuntu-latest
     steps:
@@ -33,3 +33,21 @@ jobs:
       - uses: yutailang0119/action-android-lint@v4
         with:
           report-path: 'hello-app/app/build/reports/*.xml'
+  # detekt のジョブ
+  detekt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # 静的解析
+      - name: Lint with detekt
+        run: ./gradlew detekt
+      # アーティファクトへアップロード
+      - name: Upload results Artifact
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: results
+          path: |
+            **/build/reports/detekt/*
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,35 @@
+name: Android CI lint
+
+# 実行の条件
+on:
+  pull_request:
+    paths:
+      - .github/workflows/android.yml
+      - '*/src/**'
+
+jobs:
+  android-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+          cache: gradle
+      - run: ./gradlew lint
+      - uses: yutailang0119/action-android-lint@v4
+        with:
+          report-path: 'hello-app/app/build/reports/*.xml'
+      # アーティファクトへアップロード
+      - name: Upload results Artifact
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: results
+          path: |
+            hello-app/app/build/reports/*.xml
+          retention-days: 14


### PR DESCRIPTION
gitignore の改修と適用、gradle-wrapper.jar の追加 が揃ったブランチ（feature/add_file_gradle-wrapper.jar）に対して
github actions の静的解析ワークフローを適用する 検証用PR

マージはしません。